### PR TITLE
update paraview to be able to correctly read latest exo files

### DIFF
--- a/jobs/paraview/xstartup
+++ b/jobs/paraview/xstartup
@@ -10,7 +10,7 @@ export XSTARTUP_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 . /etc/profile.d/lmod.sh
 module load virtualgl/2.5.2
-module load paraview/5.5.2
+module load paraview/5.8.0
 
 if [ -n "${IS_STRUCTURAL}" ]; then
   PARAVIEW_SCRIPT="from paraview.simple import *; GetActiveSource().ElementVariables = ['temperat - Current temperature']; GetActiveSource().PointVariables = ['Displacement', 'Stress-xx', 'Stress-yy', 'Stress-zz', 'mises stress', 'Temperature']"


### PR DESCRIPTION
update paraview to be able to correctly read latest exo files.  The issue we're seeing with flat files seems to be because Paraview doesn't read them correctly. The same exact exo file renders correctly in 5.8.0 and incorrectly in 5.5.2.